### PR TITLE
fix: StreamHandlerをstdoutに出力してRailwayでエラー扱いされないようにする

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import sys
 import uuid
 
 #from discord.ext.prometheus import PrometheusLoggingHandler
@@ -19,7 +20,7 @@ from logging import (
 from typing import Optional
 
 logger = getLogger(__name__)
-handler = StreamHandler()
+handler = StreamHandler(sys.stdout)  # stdoutに出力してRailwayでエラー扱いされないようにする
 handler.setLevel(DEBUG)
 logger.setLevel(DEBUG)
 logger.addHandler(handler)
@@ -117,7 +118,7 @@ def setup_logging(mode: Optional[str] = None):
         api_logger = getLogger("API")
         api_logger.setLevel(DEBUG)
 
-        api_stream_handler = StreamHandler()
+        api_stream_handler = StreamHandler(sys.stdout)  # stdoutに出力
         api_stream_handler.setLevel(DEBUG)
         api_stream_handler.setFormatter(CustomFormatter())
         api_logger.addHandler(api_stream_handler)
@@ -134,7 +135,7 @@ def setup_logging(mode: Optional[str] = None):
 
     logger.setLevel(level)
 
-    handler = StreamHandler()
+    handler = StreamHandler(sys.stdout)  # stdoutに出力してRailwayでエラー扱いされないようにする
     handler.setLevel(level)
     handler.setFormatter(CustomFormatter())
     logger.addHandler(handler)


### PR DESCRIPTION
## Summary

Railwayのログビューアで全てのログがエラーとして表示される問題を修正します。

Pythonの`logging.StreamHandler()`は引数なしで呼び出すとデフォルトで`sys.stderr`に出力します。Railwayは`stderr`への出力を全てエラーレベルとして分類するため、INFOやDEBUGレベルのログも赤く表示されていました。

この修正では、全ての`StreamHandler`に明示的に`sys.stdout`を指定することで、ログが正しいレベルで表示されるようにします。

## Review & Testing Checklist for Human

- [ ] 3箇所の`StreamHandler`が全て`sys.stdout`に変更されていることを確認
- [ ] Railwayにデプロイ後、ログビューアでINFO/DEBUGログがエラー（赤）として表示されなくなることを確認

### Notes

- Link to Devin run: https://app.devin.ai/sessions/4f90d0d4851b43a3a3f4ade075b791f7
- Requested by: @FreeWiFi7749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ロギング出力の改善 - すべてのログが標準出力（stdout）に正しく出力されるよう修正しました。これにより、Railway上でのエラーマーキング問題を解決します。ログレベルとフォーマッターの設定は変更されていません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->